### PR TITLE
Downloadig of self-signed or invalid certificates

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -13,7 +13,10 @@ class Downloader
 
         $streamContext = stream_context_create([
             'ssl' => [
+                'verify_peer'       => false,
                 'capture_peer_cert' => true,
+                'verify_peer_name'  => false,
+                'allow_self_signed' => true,
             ],
         ]);
 
@@ -28,10 +31,6 @@ class Downloader
         } catch (Throwable $thrown) {
             if (str_contains($thrown->getMessage(), 'getaddrinfo failed')) {
                 throw CouldNotDownloadCertificate::hostDoesNotExist($hostName);
-            }
-
-            if (str_contains($thrown->getMessage(), 'error:14090086')) {
-                throw CouldNotDownloadCertificate::noCertificateInstalled($hostName);
             }
 
             throw CouldNotDownloadCertificate::unknownError($hostName, $thrown->getMessage());

--- a/src/Exceptions/CouldNotDownloadCertificate.php
+++ b/src/Exceptions/CouldNotDownloadCertificate.php
@@ -11,11 +11,6 @@ class CouldNotDownloadCertificate extends Exception
         return new static("The host named `{$hostName}` does not exist.");
     }
 
-    public static function noCertificateInstalled(string $hostName): CouldNotDownloadCertificate
-    {
-        return new static("Could not find a certificate on  host named `{$hostName}`.");
-    }
-
     public static function unknownError(string $hostName, string $errorMessage): CouldNotDownloadCertificate
     {
         return new static("Could not download certificate for host `{$hostName}` because {$errorMessage}");

--- a/tests/DownloaderTest.php
+++ b/tests/DownloaderTest.php
@@ -27,10 +27,22 @@ class DownloaderTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function it_throws_an_exception_when_downloading_a_certificate_from_a_host_that_contains_none()
+    public function it_can_download_a_self_signed_certificated()
     {
-        $this->expectException(CouldNotDownloadCertificate::class);
+        $rawCertificateFields = Downloader::downloadCertificateFromUrl('self-signed.badssl.com');
 
-        Downloader::downloadCertificateFromUrl('www.kutfilm.be');
+        $this->assertTrue(is_array($rawCertificateFields));
+
+        $this->assertSame('/C=US/ST=California/L=San Francisco/O=BadSSL/CN=*.badssl.com', $rawCertificateFields['name']);
+    }
+
+    /** @test */
+    public function it_can_download_a_expired_certificated()
+    {
+        $rawCertificateFields = Downloader::downloadCertificateFromUrl('expired.badssl.com');
+
+        $this->assertTrue(is_array($rawCertificateFields));
+
+        $this->assertSame('/OU=Domain Control Validated/OU=PositiveSSL Wildcard/CN=*.badssl.com', $rawCertificateFields['name']);
     }
 }


### PR DESCRIPTION
This change allows the download of invalid and self-signed certificates.

This removed the exception thrown for no certificate set because a server cannot start without a certificate of some sorts. Even if you run a http server on port 443 it fails earlier on a transport error since no SSL connection can be made.

It might be a good idea to add some tests to actually test the library detects them as invalid correctly by adding the badssl.com certs as stubs, let me know if you would like that.
