### PR TITLE
Updated a possible typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ $certificate = SslCertificate::createForHostName('spatie.be');
 
 $certificate->getIssuer(); // returns "Let's Encrypt Authority X3"
 $certificate->isValid(); // returns true if the certificate is currently valid
-$certificate->getExpirationDate(); // returns an instance of Carbon
-$certificate->getExpirationDate()->diffInDays(); // returns an int
+$certificate->expirationDate(); // returns an instance of Carbon
+$certificate->expirationDate()->diffInDays(); // returns an int
 ```
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).


### PR DESCRIPTION
Looks like the example code at the top of the readme refers to an older version?