### PR TITLE
Add .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.sh
+++ b/.gitlab-ci.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -xe
+
+# Update packages and install composer and PHP dependencies.
+apt-get update -yqq
+apt-get install git libcurl4-gnutls-dev libicu-dev libmcrypt-dev libvpx-dev libjpeg-dev libpng-dev libxpm-dev zlib1g-dev libfreetype6-dev libxml2-dev libexpat1-dev libbz2-dev libgmp3-dev libldap2-dev unixodbc-dev libpq-dev libsqlite3-dev libaspell-dev libsnmp-dev libpcre3-dev libtidy-dev -yqq
+pecl install xdebug
+echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so" > /usr/local/etc/php/conf.d/xdebug.ini
+
+# Compile PHP, include these extensions.
+docker-php-ext-install mbstring mcrypt pdo_mysql curl json intl gd xml zip bz2 opcache
+
+# Install Composer and project dependencies.
+EXPECTED_SIGNATURE=$(curl https://composer.github.io/installer.sig)
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+php -r "if (hash_file('SHA384', 'composer-setup.php') === '$EXPECTED_SIGNATURE') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+php ./composer-setup.php --install-dir=/usr/local/bin --filename=composer
+PATH=$PATH:/usr/local/bin/composer
+
+# Git debug
+echo $PATH
+which git

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,8 @@
+before_script:
+  - bash .gitlab-ci.sh
+  - composer update --no-interaction --prefer-source
+
+phpunit:php7.0:
+  image: php:7.0
+  script:
+    - php vendor/bin/phpunit --colors --coverage-text --coverage-clover=coverage.clover

--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ $this->certificate->isValidUntil(Carbon::now()->addDays(7)); // returns a boolea
 ```php
 $this->certificate->isExpired(); // returns a boolean if expired
 ```
-
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
@@ -136,6 +135,8 @@ Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recen
 ``` bash
 $ composer test
 ```
+
+When working to test your implementation of this library you can use [BadSSL](https://badssl.com/) to simulate various SSL scenarios.
 
 ## Contributing
 


### PR DESCRIPTION
I generally use Gitlab and it's integrated testing, this PR will enable gitlab ci. 

Current results show as:

> $ php vendor/bin/phpunit --colors --coverage-text --coverage-clover=coverage.clover
> PHPUnit 5.5.2 by Sebastian Bergmann and contributors.
> 
> Runtime:       PHP 7.0.10 with Xdebug 2.4.1
> Configuration: /builds/MallardDuck/ssl-certificate/phpunit.xml.dist
> 
> .....................                                             21 / 21 (100%)
> 
> Time: 2.14 seconds, Memory: 6.00MB
> 
> OK (21 tests, 73 assertions)
> 
> Generating code coverage report in Clover XML format ... done
> 
> Generating code coverage report in HTML format ... done
> 
> 
> Code Coverage Report:    
>   2016-08-20 23:11:33    
>                          
>  Summary:                
>   Classes:  0.00% (0/5)  
>   Methods: 72.73% (16/22)
>   Lines:   92.31% (72/78)
> 
> \Spatie\SslCertificate::Downloader
>   Methods:   0.00% ( 0/ 1)   Lines:  92.86% ( 13/ 14)
> \Spatie\SslCertificate::SslCertificate
>   Methods:  85.71% (12/14)   Lines:  94.29% ( 33/ 35)
> \Spatie\SslCertificate::Url
>   Methods:  50.00% ( 1/ 2)   Lines:  90.00% (  9/ 10)
> \Spatie\SslCertificate\Exceptions::CouldNotDownloadCertificate
>   Methods:  66.67% ( 2/ 3)   Lines:  66.67% (  2/  3)
> \Spatie\SslCertificate\Exceptions::InvalidUrl
>   Methods:  50.00% ( 1/ 2)   Lines:  50.00% (  1/  2)