### PR TITLE
Fix wildcard matching

### DIFF
--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -123,6 +123,6 @@ class SslCertificate
 
         $wildcardHostWithoutWildcard = substr($wildcardHost, 2);
 
-        return ends_with($host, $wildcardHostWithoutWildcard);
+        return substr_count($wildcardHost, '.') >= substr_count($host, '.') && ends_with($host, $wildcardHostWithoutWildcard);
     }
 }

--- a/tests/SslCertificateTest.php
+++ b/tests/SslCertificateTest.php
@@ -138,14 +138,26 @@ class SslCertificateTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->certificate->isValid('www.spatie.be'));
 
         $this->assertFalse($this->certificate->isValid('another.spatie.be'));
+        
+        $this->assertFalse($this->certificate->isValid('www.another.spatie.be'));
+        
+        $this->assertFalse($this->certificate->isValid('another.www.another.spatie.be'));
 
         $this->assertTrue($this->certificate->isValid('otherdomain.com'));
 
         $this->assertTrue($this->certificate->isValid('www.otherdomain.com'));
 
         $this->assertTrue($this->certificate->isValid('another.otherdomain.com'));
+        
+        $this->assertFalse($this->certificate->isValid('www.another.otherdomain.com'));
+        
+        $this->assertFalse($this->certificate->isValid('another.www.another.otherdomain.com'));
 
         $this->assertFalse($this->certificate->isValid('facebook.com'));
+        
+        $this->assertFalse($this->certificate->isValid('spatie.be.facebook.com'));
+        
+        $this->assertFalse($this->certificate->isValid('www.spatie.be.facebook.com'));
     }
 
     /** @test */

--- a/tests/SslCertificateTest.php
+++ b/tests/SslCertificateTest.php
@@ -138,9 +138,9 @@ class SslCertificateTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->certificate->isValid('www.spatie.be'));
 
         $this->assertFalse($this->certificate->isValid('another.spatie.be'));
-        
+
         $this->assertFalse($this->certificate->isValid('www.another.spatie.be'));
-        
+
         $this->assertFalse($this->certificate->isValid('another.www.another.spatie.be'));
 
         $this->assertTrue($this->certificate->isValid('otherdomain.com'));
@@ -148,15 +148,15 @@ class SslCertificateTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->certificate->isValid('www.otherdomain.com'));
 
         $this->assertTrue($this->certificate->isValid('another.otherdomain.com'));
-        
+
         $this->assertFalse($this->certificate->isValid('www.another.otherdomain.com'));
-        
+
         $this->assertFalse($this->certificate->isValid('another.www.another.otherdomain.com'));
 
         $this->assertFalse($this->certificate->isValid('facebook.com'));
-        
+
         $this->assertFalse($this->certificate->isValid('spatie.be.facebook.com'));
-        
+
         $this->assertFalse($this->certificate->isValid('www.spatie.be.facebook.com'));
     }
 


### PR DESCRIPTION
The wildcard matching is currently too simple and incorrect. 

It's explained the simplest on Wikipedia: https://en.wikipedia.org/wiki/Wildcard_certificate#Example

With thanks to @JorisvanW for simplifying the implementation.