### PR TITLE
Add Object-to-String casting and wildcard chain bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `ssl-certificate` will be documented in this file
 ## 1.4.0 - 2017-08-10
 
 - add `getCertificates` method on Downloader.
-- add `usingSni` and `withFullChain` method on Downloader.
+- add `usingSni`, `withFullChain`, `withVerifyPeer` and `withVerifyPeerName` method on Downloader.
 
 ## 1.3.2 - 2017-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `ssl-certificate` will be documented in this file
 ## 1.4.0 - 2017-08-10
 
 - add `getCertificates` method on Downloader.
+- add `usingSni` and `withFullChain` method on Downloader.
 
 ## 1.3.2 - 2017-07-18
 

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -71,17 +71,20 @@ class Downloader
     {
         $response = $this->fetchCertificates($hostName);
 
+
         $peerCertificate = $response['options']['ssl']['peer_certificate'];
 
         $peerCertificateChain = $response['options']['ssl']['peer_certificate_chain'] ?? [];
 
         $fullCertificateChain = array_merge([$peerCertificate], $peerCertificateChain);
 
-        return array_map(function ($certificate) {
+        // Filter duplicates: wildcard SSL certs are reported in both
+        // 'peer_certificate' as well as 'peer_certificate_chain'
+        return array_unique(array_map(function ($certificate) {
             $certificateFields = openssl_x509_parse($certificate);
 
             return new SslCertificate($certificateFields);
-        }, $fullCertificateChain);
+        }, $fullCertificateChain));
     }
 
     public function forHost(string $hostName): SslCertificate

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -19,6 +19,12 @@ class Downloader
     /** @var bool */
     protected $capturePeerChain = false;
 
+    /** @var bool */
+    protected $verifyPeer = true;
+
+    /** @var bool */
+    protected $verifyPeerName = true;
+
     /**
      * @param int $port
      *
@@ -51,6 +57,30 @@ class Downloader
     public function withFullChain(bool $ca_chain)
     {
         $this->capturePeerChain = $ca_chain;
+
+        return $this;
+    }
+
+    /**
+     * @param int $verify_peer
+     *
+     * @return $this
+     */
+    public function withVerifyPeer(bool $verify_peer)
+    {
+        $this->verifyPeer = $verify_peer;
+
+        return $this;
+    }
+
+    /**
+     * @param int $verify_peer_name
+     *
+     * @return $this
+     */
+    public function withVerifyPeerName(bool $verify_peer_name)
+    {
+        $this->verifyPeerName = $verify_peer_name;
 
         return $this;
     }
@@ -110,6 +140,8 @@ class Downloader
             'capture_peer_cert' => true,
             'capture_peer_cert_chain' => $this->capturePeerChain,
             'SNI_enabled' => $this->enableSni,
+            'verify_peer' => $this->verifyPeer,
+            'verify_peer_name' => $this->verifyPeerName,
         ];
 
         $streamContext = stream_context_create([

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -71,7 +71,6 @@ class Downloader
     {
         $response = $this->fetchCertificates($hostName);
 
-
         $peerCertificate = $response['options']['ssl']['peer_certificate'];
 
         $peerCertificateChain = $response['options']['ssl']['peer_certificate_chain'] ?? [];

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -13,6 +13,12 @@ class Downloader
     /** @var int */
     protected $timeout = 30;
 
+    /** @var bool */
+    protected $sni = true;
+
+    /** @var bool */
+    protected $ca_chain = false;
+
     /**
      * @param int $port
      *
@@ -21,6 +27,30 @@ class Downloader
     public function usingPort(int $port)
     {
         $this->port = $port;
+
+        return $this;
+    }
+
+    /**
+     * @param int $port
+     *
+     * @return $this
+     */
+    public function usingSni(bool $sni)
+    {
+        $this->sni = $sni;
+
+        return $this;
+    }
+
+    /**
+     * @param int $port
+     *
+     * @return $this
+     */
+    public function withFullChain(bool $ca_chain)
+    {
+        $this->ca_chain = $ca_chain;
 
         return $this;
     }
@@ -37,14 +67,18 @@ class Downloader
         return $this;
     }
 
-    public function forHost(string $hostName): SslCertificate
+    public function getCertificates(string $hostName): array
     {
         $hostName = (new Url($hostName))->getHostName();
 
+        $ssl_options = [
+            'capture_peer_cert' => true,
+            'capture_peer_cert_chain' => $this->ca_chain,
+            'SNI_enabled' => $this->sni,
+        ];
+
         $streamContext = stream_context_create([
-            'ssl' => [
-                'capture_peer_cert' => true,
-            ],
+            'ssl' => $ssl_options,
         ]);
 
         try {
@@ -74,9 +108,26 @@ class Downloader
 
         $response = stream_context_get_params($client);
 
-        $certificateFields = openssl_x509_parse($response['options']['ssl']['peer_certificate']);
+        $peer_certificate = $response['options']['ssl']['peer_certificate'];
+        $peer_certificate_chain = $response['options']['ssl']['peer_certificate_chain'] ?? [];
+        $certificates = array_merge ([ $peer_certificate ], $peer_certificate_chain);
 
-        return new SslCertificate($certificateFields);
+        $return = [];
+        foreach ($certificates as $certificate) {
+          $certificateFields = openssl_x509_parse($certificate);
+          $return[] = new SslCertificate($certificateFields);
+        }
+
+        return $return;
+    }
+
+    public function forHost(string $hostName): SslCertificate
+    {
+        $hostName = (new Url($hostName))->getHostName();
+
+        $certificates = $this->getCertificates($hostName);
+
+        return $certificates[0] ?? false;
     }
 
     public static function downloadCertificateFromUrl(string $url, int $timeout = 30): SslCertificate

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -110,12 +110,12 @@ class Downloader
 
         $peer_certificate = $response['options']['ssl']['peer_certificate'];
         $peer_certificate_chain = $response['options']['ssl']['peer_certificate_chain'] ?? [];
-        $certificates = array_merge ([ $peer_certificate ], $peer_certificate_chain);
+        $certificates = array_merge([ $peer_certificate ], $peer_certificate_chain);
 
         $return = [];
         foreach ($certificates as $certificate) {
-          $certificateFields = openssl_x509_parse($certificate);
-          $return[] = new SslCertificate($certificateFields);
+            $certificateFields = openssl_x509_parse($certificate);
+            $return[] = new SslCertificate($certificateFields);
         }
 
         return $return;

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -32,7 +32,7 @@ class Downloader
     }
 
     /**
-     * @param int $port
+     * @param int $sni
      *
      * @return $this
      */
@@ -44,7 +44,7 @@ class Downloader
     }
 
     /**
-     * @param int $port
+     * @param int $ca_chain
      *
      * @return $this
      */

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -110,7 +110,7 @@ class Downloader
 
         $peer_certificate = $response['options']['ssl']['peer_certificate'];
         $peer_certificate_chain = $response['options']['ssl']['peer_certificate_chain'] ?? [];
-        $certificates = array_merge([ $peer_certificate ], $peer_certificate_chain);
+        $certificates = array_merge([$peer_certificate], $peer_certificate_chain);
 
         $return = [];
         foreach ($certificates as $certificate) {

--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -125,4 +125,19 @@ class SslCertificate
 
         return substr_count($wildcardHost, '.') >= substr_count($host, '.') && ends_with($host, $wildcardHostWithoutWildcard);
     }
+
+    public function getRawCertificateFieldsJson(): string
+    {
+      return json_encode($this->getRawCertificateFields());
+    }
+
+    public function getHash(): string
+    {
+      return md5(json_encode($this->getRawCertificateFieldsJson()));
+    }
+
+    public function __toString(): string
+    {
+      return $this->getRawCertificateFieldsJson();
+    }
 }

--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -133,7 +133,7 @@ class SslCertificate
 
     public function getHash(): string
     {
-        return md5(json_encode($this->getRawCertificateFieldsJson()));
+        return md5($this->getRawCertificateFieldsJson());
     }
 
     public function __toString(): string

--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -128,16 +128,16 @@ class SslCertificate
 
     public function getRawCertificateFieldsJson(): string
     {
-      return json_encode($this->getRawCertificateFields());
+        return json_encode($this->getRawCertificateFields());
     }
 
     public function getHash(): string
     {
-      return md5(json_encode($this->getRawCertificateFieldsJson()));
+        return md5(json_encode($this->getRawCertificateFieldsJson()));
     }
 
     public function __toString(): string
     {
-      return $this->getRawCertificateFieldsJson();
+        return $this->getRawCertificateFieldsJson();
     }
 }


### PR DESCRIPTION
This PR fixes 2 things;

1) It adds `__toString()` on the `SslCertificate` to allow objects to be used in array filters like `array_unique()`

2) It bugfixes a problem where wildcard certificates get reported in both the `peer_certificate` as well as `peer_certificate_chain`, giving the impression that a certificate exists twice (which it doesn't). In that case, duplicate certificates get removed and only its unique values remain.