### PR TITLE
Add option for the certificate fingerprint

### DIFF
--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -11,6 +11,7 @@ class SslCertificate
 
     /** @var array */
     protected $rawCertificateFields = [];
+    protected $rawCertificate = "";
 
     public static function download(): Downloader
     {
@@ -24,9 +25,10 @@ class SslCertificate
         return $sslCertificate;
     }
 
-    public function __construct(array $rawCertificateFields)
+    public function __construct(array $rawCertificateFields, string $rawCertificate = "")
     {
         $this->rawCertificateFields = $rawCertificateFields;
+        $this->rawCertificate = $rawCertificate;
     }
 
     public function getRawCertificateFields(): array
@@ -171,6 +173,16 @@ class SslCertificate
     public function getHash(): string
     {
         return md5($this->getRawCertificateFieldsJson());
+    }
+
+    public function getFingerprint(): string
+    {
+        if (strlen($this->rawCertificate) > 0) {
+            return openssl_x509_fingerprint($this->rawCertificate);
+        } else {
+            // Raw certificate wasn't provided, can't get fingerprint
+            return "";
+        }
     }
 
     public function __toString(): string


### PR DESCRIPTION
Add option for the certificate fingerprint, but requires the original certificate is given as a parameter to the constructor.

Aka:
```
$cert = '-----BEGIN CERTIFICATE----- ..... -----END CERTIFICATE-----';
$parsedCertificate = openssl_x509_parse($cert);
$object = new SslCertificate($parsedCertificate, $cert);
```

Alternative, the input to `SslCertificate` could be the string representation in the first place (meaning the value of `$cert`, so `openssl_x509_parse ` happens in `SslCertificate`, instead of outside it), but would be a major breaking change since it would require changing all input to `SslCertificate`.