### PR TITLE
Only return unique domain names

### DIFF
--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -126,7 +126,7 @@ class SslCertificate
 
     public function getDomains(): array
     {
-        return array_filter(array_merge([$this->getDomain()], $this->getAdditionalDomains()));
+        return array_unique(array_filter(array_merge([$this->getDomain()], $this->getAdditionalDomains())));
     }
 
     public function appliesToUrl(string $url): bool


### PR DESCRIPTION
Often times, the main domain is repeated in the SAN again, causing it to appear twice in the getDomains() list. Filter only the unique values, there's no point in reporting domains twice or more.