### PR TITLE
getDomain(): if the subject consists of more than 1 domain, pick the first

### DIFF
--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -126,7 +126,7 @@ class SslCertificate
 
     public function getDomains(): array
     {
-        return array_filter(array_merge([$this->getDomain()], $this->getAdditionalDomains()));
+        return array_unique(array_filter(array_merge([$this->getDomain()], $this->getAdditionalDomains())));
     }
 
     public function appliesToUrl(string $url): bool

--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -140,15 +140,11 @@ class SslCertificate
 
     public function getDomains(): array
     {
-<<<<<<< HEAD
-        return array_unique(array_filter(array_merge([$this->getDomain()], $this->getAdditionalDomains())));
-=======
         $allDomains = array_merge([$this->getDomain()], $this->getAdditionalDomains());
 
         $uniqueDomains = array_unique($allDomains);
 
         return array_values(array_filter($uniqueDomains));
->>>>>>> b08f83f2e0322781d4cacb44d7bd2fabe3943202
     }
 
     public function appliesToUrl(string $url): bool

--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -41,7 +41,21 @@ class SslCertificate
 
     public function getDomain(): string
     {
-        return $this->rawCertificateFields['subject']['CN'] ?? '';
+        if (! array_key_exists('CN', $this->rawCertificateFields['subject'])) {
+            return '';
+        }
+
+        /* Common Name is a string */
+        if (is_string($this->rawCertificateFields['subject']['CN'])) {
+            return $this->rawCertificateFields['subject']['CN'];
+        }
+
+        /* Common name is an array consisting of multiple domains, take the first one */
+        if (is_array($this->rawCertificateFields['subject']['CN'])) {
+            return $this->rawCertificateFields['subject']['CN'][0];
+        }
+
+        return '';
     }
 
     public function getSignatureAlgorithm(): string


### PR DESCRIPTION
In some rare cases, a Common Name consists of multiple domains, instead of a single one. This covers that edge case and returns the first element if it's an array.