### PR TITLE
getDomains(): do not use the Common Name, it's no longer being validated in Chrome

### DIFF
--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -126,7 +126,7 @@ class SslCertificate
 
     public function getDomains(): array
     {
-        return array_filter(array_merge([$this->getDomain()], $this->getAdditionalDomains()));
+        return array_unique(array_filter(array_merge([$this->getDomain()], $this->getAdditionalDomains())));
     }
 
     public function appliesToUrl(string $url): bool

--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -140,15 +140,11 @@ class SslCertificate
 
     public function getDomains(): array
     {
-<<<<<<< HEAD
-        return array_unique(array_filter(array_merge([$this->getDomain()], $this->getAdditionalDomains())));
-=======
         $allDomains = array_merge([$this->getDomain()], $this->getAdditionalDomains());
 
         $uniqueDomains = array_unique($allDomains);
 
         return array_values(array_filter($uniqueDomains));
->>>>>>> b08f83f2e0322781d4cacb44d7bd2fabe3943202
     }
 
     public function appliesToUrl(string $url): bool

--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -41,7 +41,21 @@ class SslCertificate
 
     public function getDomain(): string
     {
-        return $this->rawCertificateFields['subject']['CN'] ?? '';
+        if (! array_key_exists('CN', $this->rawCertificateFields['subject'])) {
+            return '';
+        }
+
+        /* Common Name is a string */
+        if (is_string($this->rawCertificateFields['subject']['CN'])) {
+            return $this->rawCertificateFields['subject']['CN'];
+        }
+
+        /* Common name is an array consisting of multiple domains, take the first one */
+        if (is_array($this->rawCertificateFields['subject']['CN'])) {
+            return $this->rawCertificateFields['subject']['CN'][0];
+        }
+
+        return '';
     }
 
     public function getSignatureAlgorithm(): string

--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -140,7 +140,7 @@ class SslCertificate
 
     public function getDomains(): array
     {
-        $allDomains = array_merge([$this->getDomain()], $this->getAdditionalDomains());
+        $allDomains = $this->getAdditionalDomains();
 
         $uniqueDomains = array_unique($allDomains);
 


### PR DESCRIPTION
ref: https://www.thesslstore.com/blog/security-changes-in-chrome-58/

```
Many people don’t know that the “Common Name” field of an SSL certificate, which contains the domain name the certificate is valid for, was actually phased-out via RFC nearly two decades ago. Instead, the SAN (Subject Alternative Name) field is the proper place to list the domain(s).

However, this has been ignored and for many years the Common Name field was exclusively used. Chrome is finally fed up with the field that refuses to die. In Chrome 58, the Common Name field is now ignored entirely.
```