### PR TITLE
getDomains(): do not use the Common Name, obsoleted

### DIFF
--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -140,7 +140,7 @@ class SslCertificate
 
     public function getDomains(): array
     {
-        $allDomains = array_merge([$this->getDomain()], $this->getAdditionalDomains());
+        $allDomains = $this->getAdditionalDomains();
 
         $uniqueDomains = array_unique($allDomains);
 


### PR DESCRIPTION
ref: https://www.thesslstore.com/blog/security-changes-in-chrome-58/

```
Many people don’t know that the “Common Name” field of an SSL certificate, which contains the domain name the certificate is valid for, was actually phased-out via RFC nearly two decades ago. Instead, the SAN (Subject Alternative Name) field is the proper place to list the domain(s).

However, this has been ignored and for many years the Common Name field was exclusively used. Chrome is finally fed up with the field that refuses to die. In Chrome 58, the Common Name field is now ignored entirely.
```