### PR TITLE
Convert IDN to ASCII before attempting to validate

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -18,6 +18,8 @@ class Url
             $url = "https://{$url}";
         }
 
+        $url = idn_to_ascii($url);
+
         if (! filter_var($url, FILTER_VALIDATE_URL)) {
             throw InvalidUrl::couldNotValidate($url);
         }

--- a/src/Url.php
+++ b/src/Url.php
@@ -18,7 +18,7 @@ class Url
             $url = "https://{$url}";
         }
 
-        $url = idn_to_ascii($url);
+        $url = idn_to_ascii($url, false, INTL_IDNA_VARIANT_UTS46);
 
         if (! filter_var($url, FILTER_VALIDATE_URL)) {
             throw InvalidUrl::couldNotValidate($url);


### PR DESCRIPTION
This is a workaround for failed IDN validations. This appears to be a known, yet unfixed, problem in PHP:
- https://bugs.php.net/bug.php?id=53474
- https://bugs.php.net/bug.php?id=73176

`idn_to_ascii()` is used to convert the IDN to an ASCII representation for the validation, afterwards that ASCII form is used to make the actual calls to the URL. Libcurl handles the rest.