### PR TITLE
Fix failing test case

### DIFF
--- a/tests/DownloaderTest.php
+++ b/tests/DownloaderTest.php
@@ -54,6 +54,6 @@ class DownloaderTest extends TestCase
     {
         $this->expectException(CouldNotDownloadCertificate::class);
 
-        Downloader::downloadCertificateFromUrl('www.kutfilm.be');
+        Downloader::downloadCertificateFromUrl('3564020356.org');
     }
 }


### PR DESCRIPTION
It seems that www.kutfilm.be has a certificate now, so the `it_throws_an_exception_when_downloading_a_certificate_from_a_host_that_contains_none()` test no longer passes.

I initially tried using http.badssl.com but it turns out the IP it resolves to does have a valid cert on port 443, so that wouldn't work here.

Seeing as most of the web is moving towards SSL these days (which is awesome!) I had to think of the oldest site I know of that probably doesn't have SSL and may never will.  I came up with [3564020356.org](http://3564020356.org) which is an old site (circa 2001) where I learned the basics of reverse engineering and cryptography back in the day.  If it's been online this long I can't imagine it going offline any time soon, so perhaps this could be used for the test instead?