### PR TITLE
Allow Carbon 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.0",
         "ext-intl" : "*",
-        "nesbot/carbon": "^1.15",
+        "nesbot/carbon": "^1.15|^2.0",
         "spatie/macroable": "^1.0"
     },
     "require-dev": {

--- a/tests/DownloaderTest.php
+++ b/tests/DownloaderTest.php
@@ -54,6 +54,6 @@ class DownloaderTest extends TestCase
     {
         $this->expectException(CouldNotDownloadCertificate::class);
 
-        Downloader::downloadCertificateFromUrl('www.kutfilm.be');
+        Downloader::downloadCertificateFromUrl('3564020356.org');
     }
 }


### PR DESCRIPTION
This library only uses 3 methods which are present in both Carbon 1 and 2 so why not allow developers to use v2 if they prefer?

The existing Travis CI config should end up testing both Carbon v1 and v2 where possible to confirm that this works.

Note this this also contains the same test fix introduced in #76 (so maybe review/merge that first)