### PR TITLE
Fix SSL check for IP addresses that serve a valid SSL, i.e. 1.1.1.1

### DIFF
--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -157,11 +157,9 @@ class SslCertificate
 
     public function appliesToUrl(string $url): bool
     {
-        if(filter_var($url, FILTER_VALIDATE_IP))
-        {
+        if(filter_var($url, FILTER_VALIDATE_IP)) {
             $host = $url;
-        } else
-        {
+        } else {
             $host = (new Url($url))->getHostName();
         }
 

--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -157,13 +157,18 @@ class SslCertificate
 
     public function appliesToUrl(string $url): bool
     {
-        $host = (new Url($url))->getHostName();
+        if(filter_var($url, FILTER_VALIDATE_IP))
+        {
+            $host = $url;
+        } else
+        {
+            $host = (new Url($url))->getHostName();
+        }
 
         $certificateHosts = $this->getDomains();
 
         foreach ($certificateHosts as $certificateHost) {
-            $certificateHost = strtolower($certificateHost);
-
+            $certificateHost = str_replace('ip address:', '', strtolower($certificateHost));
             if ($host === $certificateHost) {
                 return true;
             }


### PR DESCRIPTION
1.1.1.1 is CloudFlare's DNS IP address that has a valid SSL certificate. But this package doesn't validate that IP address' SSL certificate. My PR fixes that issue.