### PR TITLE
Check for missing 'INTL_IDNA_VARIANT_UTS46' to constant

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -19,7 +19,11 @@ class Url
         }
 
         if (strlen($url) < 61 && function_exists('idn_to_ascii')) {
-            $url = idn_to_ascii($url, false, INTL_IDNA_VARIANT_UTS46);
+            if (defined('INTL_IDNA_VARIANT_UTS46')) {
+                $url = idn_to_ascii($url, false, INTL_IDNA_VARIANT_UTS46);
+            } else {
+                $url = idn_to_ascii($url);
+            }
         }
 
         if (! filter_var($url, FILTER_VALIDATE_URL)) {


### PR DESCRIPTION
Environments running PHP7.1 with an ICU version < 4.6 will not have the 'INTL_IDNA_VARIANT_UTS46' defined. Even though the `idn_to_ascii()` function exists.

This will check for the constant, and fall back to using the `idn_to_ascii()` defaults if it does not exist.