### PR TITLE
Silence warnings from stream_socket_client() in Spatie\SslCertificate\Downloader

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -3,7 +3,6 @@
 namespace Spatie\SslCertificate;
 
 use Spatie\SslCertificate\Exceptions\CouldNotDownloadCertificate;
-use Throwable;
 
 class Downloader
 {
@@ -137,11 +136,11 @@ class Downloader
             $streamContext
         );
 
-        if (!empty($errorDescription)) {
+        if (! empty($errorDescription)) {
             throw $this->generateFailureException($hostName, $errorDescription);
         }
 
-        if (!$client) {
+        if (! $client) {
             throw CouldNotDownloadCertificate::unknownError($hostName, "Could not connect to `{$hostName}`.");
         }
 

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -129,7 +129,7 @@ class Downloader
         ]);
 
         try {
-            $client = stream_socket_client(
+            $client = @stream_socket_client(
                 "ssl://{$hostName}:{$this->port}",
                 $errorNumber,
                 $errorDescription,


### PR DESCRIPTION
If the `Downloader` is asked to fetch a certificate from an unresolvable / un-connectable URL then `stream_socket_client()` will generate PHP warnings. 

Test code:
```php
<?php

use Spatie\SslCertificate\SslCertificate;

require 'vendor/autoload.php';

try {
    $certificate = SslCertificate::createForHostName('www.non-existent-domain-name-here.com');
    echo "Succeeded";
} catch (\Exception $e) {
    echo "Failed";
}
```

Expected output:
```$ php test.php
Failed
```

Actual output:
```$ php test.php
PHP Warning:  stream_socket_client(): php_network_getaddresses: getaddrinfo failed: nodename nor servname provided, or not known in /ssl-certificate/src/Downloader.php on line 138

Warning: stream_socket_client(): php_network_getaddresses: getaddrinfo failed: nodename nor servname provided, or not known in /ssl-certificate/src/Downloader.php on line 138
PHP Warning:  stream_socket_client(): unable to connect to ssl://www.non-existent-domain-name-here.com:443 (php_network_getaddresses: getaddrinfo failed: nodename nor servname provided, or not known) in /ssl-certificate/src/Downloader.php on line 138

Warning: stream_socket_client(): unable to connect to ssl://www.non-existent-domain-name-here.com:443 (php_network_getaddresses: getaddrinfo failed: nodename nor servname provided, or not known) in /ssl-certificate/src/Downloader.php on line 138
```

This PR silences the warnings thrown by `stream_socket_client()`, any errors will be picked up by the check of the `$client` returned.