### PR TITLE
Add function to get certificate for hostname from IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ SslCertificate::download()
 You can also check the certificate on a different IP address using the same style.
 ```php
 SslCertificate::download()
-   ->setIpAddress($ipAddress)
+   ->fromIpAddress($ipAddress)
    ->forHost($hostName);
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ SslCertificate::download()
    ->forHost($hostName);
 ```
 
+You can also check the certificate on a different IP address using the same style.
+```php
+SslCertificate::download()
+   ->setIpAddress($ipAddress)
+   ->forHost($hostName);
+```
+
+If the given `ipAddress` is invalid `Spatie\SslCertificate\Exceptions\InvalidIpAddress` will be thrown.
+
 If the given `hostName` is invalid `Spatie\SslCertificate\Exceptions\InvalidUrl` will be thrown.
 
 If the given `hostName` is valid but there was a problem downloading the certifcate `Spatie\SslCertificate\Exceptions\CouldNotDownloadCertificate` will be thrown.

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -74,7 +74,7 @@ class Downloader
         return $this;
     }
 
-    public function setIpAddress(string $ipAddress)
+    public function fromIpAddress(string $ipAddress)
     {
         if (! filter_var($ipAddress, FILTER_VALIDATE_IP)) {
             throw InvalidIpAddress::couldNotValidate($ipAddress);
@@ -147,11 +147,9 @@ class Downloader
             'ssl' => $sslOptions,
         ]);
 
-        if ($this->usingIpAddress) {
-            $connectTo = $this->ipAddress;
-        } else {
-            $connectTo = $hostName;
-        }
+        $connectTo = ($this->usingIpAddress)
+            ? $connectTo = $this->ipAddress
+            : $connectTo = $hostName;
 
         try {
             $client = stream_socket_client(
@@ -167,14 +165,11 @@ class Downloader
         }
 
         if (! $client) {
-            if ($this->usingIpAddress) {
-                throw CouldNotDownloadCertificate::unknownError(
-                    $hostName,
-                    "Could not connect to `{$connectTo}` or it does not have a certificate matching `${hostName}`."
-                );
-            } else {
-                throw CouldNotDownloadCertificate::unknownError($hostName, "Could not connect to `{$connectTo}`.");
-            }
+            $clientErrorMessage = ($this->usingIpAddress)
+                ? "Could not connect to `{$connectTo}` or it does not have a certificate matching `${hostName}`."
+                : "Could not connect to `{$connectTo}`.";
+
+            throw CouldNotDownloadCertificate::unknownError($hostName, $clientErrorMessage);
         }
 
         $response = stream_context_get_params($client);

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -148,8 +148,8 @@ class Downloader
         ]);
 
         $connectTo = ($this->usingIpAddress)
-            ? $connectTo = $this->ipAddress
-            : $connectTo = $hostName;
+            ? $this->ipAddress
+            : $hostName;
 
         try {
             $client = stream_socket_client(

--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -35,8 +35,8 @@ class SslCertificate
         array $rawCertificateFields,
         string $fingerprint = '',
         string $fingerprintSha256 = '',
-        string $remoteAddress = '')
-    {
+        string $remoteAddress = ''
+    ) {
         $this->rawCertificateFields = $rawCertificateFields;
 
         $this->fingerprint = $fingerprint;

--- a/tests/DownloaderTest.php
+++ b/tests/DownloaderTest.php
@@ -27,6 +27,16 @@ class DownloaderTest extends TestCase
     }
 
     /** @test */
+    public function it_can_download_a_certificate_for_a_host_name_from_an_ip_address()
+    {
+        $sslCertificate = SslCertificate::download()
+            ->setIpAddress('138.197.187.74')
+            ->forHost('spatie.be');
+
+        $this->assertInstanceOf(SslCertificate::class, $sslCertificate);
+    }
+
+    /** @test */
     public function it_sets_a_fingerprint_on_the_downloaded_certificate()
     {
         $sslCertificate = Downloader::downloadCertificateFromUrl('spatie.be');
@@ -56,6 +66,16 @@ class DownloaderTest extends TestCase
         $this->expectException(UnknownError::class);
 
         Downloader::downloadCertificateFromUrl('3564020356.org');
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_downloading_a_certificate_for_a_missing_host_name_from_an_ip_address()
+    {
+        $this->expectException(UnknownError::class);
+
+        $sslCertificate = SslCertificate::download()
+            ->setIpAddress('138.197.187.74')
+            ->forHost('fake.subdomain.spatie.be');
     }
 
     /** @test */

--- a/tests/DownloaderTest.php
+++ b/tests/DownloaderTest.php
@@ -30,7 +30,7 @@ class DownloaderTest extends TestCase
     public function it_can_download_a_certificate_for_a_host_name_from_an_ip_address()
     {
         $sslCertificate = SslCertificate::download()
-            ->setIpAddress('138.197.187.74')
+            ->fromIpAddress('138.197.187.74')
             ->forHost('spatie.be');
 
         $this->assertInstanceOf(SslCertificate::class, $sslCertificate);
@@ -74,7 +74,7 @@ class DownloaderTest extends TestCase
         $this->expectException(UnknownError::class);
 
         $sslCertificate = SslCertificate::download()
-            ->setIpAddress('138.197.187.74')
+            ->fromIpAddress('138.197.187.74')
             ->forHost('fake.subdomain.spatie.be');
     }
 


### PR DESCRIPTION
This can be used to check whether a particular IP address has a certificate matching the provided host name. One of the use cases would be ensuring backend compliance - this would allow you to check the certificate's expiry date and validity on the origin servers as well, e.g. if they are behind a load balancer or the traffic is proxied through Cloudflare.