### PR TITLE
Add option to disable certificate validation in createForHostName

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $certificate->getOrganization(); // returns the organization name when available
 
 #### Downloading invalid certificate
 
-If you want to download certificates even if they are invalid (for example, if they are expired), you can pass the `$verifyCertificate` to `SslCertificate::createFromHostname()`, for example:
+If you want to download certificates even if they are invalid (for example, if they are expired), you can pass a `$verifyCertificate` boolean to `SslCertificate::createFromHostname()` as the third argument, for example:
 
 ```
 $certificate = SslCertificate::createForHostName('expired.badssl.com', 30, false);

--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ $certificate->getSignatureAlgorithm(); // returns a string
 $certificate->getOrganization(); // returns the organization name when available
 ```
 
+#### Downloading invalid certificate
+
+If you want to download certificates even if they are invalid (for example, if they are expired), you can pass the `$verifyCertificate` to `SslCertificate::createFromHostname()`, for example:
+
+```
+$certificate = SslCertificate::createForHostName('expired.badssl.com', 30, false);
+```
+
+## About us
+
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
 ## Support us

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -132,7 +132,7 @@ class Downloader
         return $certificates[0] ?? false;
     }
 
-    public static function downloadCertificateFromUrl(string $url, int $timeout = 30, bool $verifyCertificate): SslCertificate
+    public static function downloadCertificateFromUrl(string $url, int $timeout = 30, bool $verifyCertificate = true): SslCertificate
     {
         return (new static())
             ->setTimeout($timeout)

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -132,10 +132,12 @@ class Downloader
         return $certificates[0] ?? false;
     }
 
-    public static function downloadCertificateFromUrl(string $url, int $timeout = 30): SslCertificate
+    public static function downloadCertificateFromUrl(string $url, int $timeout = 30, bool $verifyCertificate): SslCertificate
     {
         return (new static())
             ->setTimeout($timeout)
+            ->withVerifyPeer($verifyCertificate)
+            ->withVerifyPeerName($verifyCertificate)
             ->forHost($url);
     }
 

--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -26,9 +26,9 @@ class SslCertificate
         return new Downloader();
     }
 
-    public static function createForHostName(string $url, int $timeout = 30): self
+    public static function createForHostName(string $url, int $timeout = 30, bool $verifyCertificate = true): self
     {
-        return Downloader::downloadCertificateFromUrl($url, $timeout);
+        return Downloader::downloadCertificateFromUrl($url, $timeout, $verifyCertificate);
     }
 
     public static function createFromFile(string $pathToCertificate): self


### PR DESCRIPTION
I believe downloading invalid certificates is a pretty common use case (see: #69 #124 #82 ) so this PR adds an argument to `createForHostname` to make it easy to enable downloading of invalid certificates. Also documents this option.