### PR TITLE
Update example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $certificate->getOrganization(); // returns the organization name when available
 If you want to download certificates even if they are invalid (for example, if they are expired), you can pass a `$verifyCertificate` boolean to `SslCertificate::createFromHostname()` as the third argument, for example:
 
 ```
-$certificate = SslCertificate::createForHostName('expired.badssl.com', 30, false);
+$certificate = SslCertificate::createForHostName('expired.badssl.com', $timeoutInSeconds, false);
 ```
 
 ## About us


### PR DESCRIPTION
List meaningful variable in code example instead of random number.
Had lookup what the second param was in the class, this just makes it a bit easier to understand when browsing the docs/readme 