### PR TITLE
Fix getOrganization method which always returned an empty result

### DIFF
--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -99,7 +99,7 @@ class SslCertificate
 
     public function getOrganization(): string
     {
-        return $this->rawCertificateFields['subject']['O'] ?? '';
+        return $this->rawCertificateFields['issuer']['O'] ?? '';
     }
 
     public function getFingerprint(): string

--- a/tests/SslCertificateFromStringTest.php
+++ b/tests/SslCertificateFromStringTest.php
@@ -32,6 +32,12 @@ class SslCertificateFromStringTest extends TestCase
     }
 
     /** @test */
+    public function it_can_determine_the_organization()
+    {
+        $this->assertSame("Let's Encrypt", $this->certificate->getOrganization());
+    }
+
+    /** @test */
     public function it_can_determine_the_domain()
     {
         $this->assertSame('analytics.spatie.be', $this->certificate->getDomain());


### PR DESCRIPTION
Information about the organization is in `['issuer']['O']` and not in `['subject']['O']`