### PR TITLE
Fix potential memory leak

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -201,7 +201,9 @@ class Downloader
 
             $response['remoteAddress'] = stream_socket_get_name($client, true);
         } finally {
-            fclose($client);
+            if ($client !== false) {
+                fclose($client);
+            }
         }
 
         return $response;


### PR DESCRIPTION
This PR fixes a potential memory leak in the `Downloader` class: 
- `fetchCertificates()` does not close the stream socket client when an exception is thrown.