### PR TITLE
Provide compatibility with officially supported versions of php.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": ">=7.3",
         "ext-intl": "*",
         "ext-json": "*",
         "nesbot/carbon": "^2.23",


### PR DESCRIPTION
Since PHP 7.3 is still publicly supported, libraries that depend on this package need it to still support the oldest supported version of php, which as of Summer 2021, is 7.3.

I haven't been able to run tests on this yet, but hopefully the test runner can tell us if the version increment from 7.2 to 7.4 was policy driven or for a technical reason.