### PR TITLE
Remove follow_location

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -156,7 +156,6 @@ class Downloader
             'peer_name' => $hostName,
             'verify_peer' => $this->verifyPeer,
             'verify_peer_name' => $this->verifyPeerName,
-            'follow_location' => $this->followLocation,
         ];
 
         $streamContext = stream_context_create([


### PR DESCRIPTION
follow_location belongs to HTTP context options, is useless using follow_location inside SSL context options
Please check:
SSL context options: https://www.php.net/manual/en/context.ssl.php
HTTP context options: https://www.php.net/manual/en/context.http.php