### PR TITLE
Keep original unknown error message

### DIFF
--- a/src/Exceptions/CouldNotDownloadCertificate/UnknownError.php
+++ b/src/Exceptions/CouldNotDownloadCertificate/UnknownError.php
@@ -6,8 +6,16 @@ use Spatie\SslCertificate\Exceptions\CouldNotDownloadCertificate;
 
 class UnknownError extends CouldNotDownloadCertificate
 {
+    protected string $errorMessage;
+
     public function __construct(string $hostName, string $errorMessage)
     {
         parent::__construct("Could not download certificate for host `{$hostName}` because {$errorMessage}");
+
+        $this->errorMessage = $errorMessage;
+    }
+
+    public function getOriginalMessage(): string {
+        return $this->errorMessage;
     }
 }


### PR DESCRIPTION
I need the original, technical message, not the full human readable exception message. With this change, that error message is retrievable.

----

Instead of

> Could not download certificate for host `example.com` because Could not connect to `example.com`.

I only want

> Could not connect to `example.com`.
