### PR TITLE
Throw exception for sites with no SSL support

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -202,6 +202,10 @@ class Downloader
 
         $response['remoteAddress'] = stream_socket_get_name($client, true);
 
+        if (empty($response['options']['ssl']['peer_certificate']) && empty($response['options']['ssl']['peer_certificate_chain'])) {
+            throw CouldNotDownloadCertificate::unknownError($hostName, "Could not connect to `{$connectTo}`.");
+        }
+
         fclose($client);
 
         return $response;


### PR DESCRIPTION
Thank you for the library, It helped me a lot with automating the SSL expiry check for bulk of domains.
I only found an issue when there is a domain with no SSL enabled, it did not work, a fatal error raises and no exception thrown.

I am not sure how to include a test for this feature, because I was not able to find a public domain with no SSL support to add to the test scenario. 
It worked for me on a domain with the same issue on the domains list I have.

I hope this would help!.

