### PR TITLE
Display connecting port in error message

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -192,8 +192,8 @@ class Downloader
 
         if (! $client) {
             $clientErrorMessage = ($this->usingIpAddress)
-                ? "Could not connect to `{$connectTo}` or it does not have a certificate matching `{$hostName}`."
-                : "Could not connect to `{$connectTo}`.";
+                ? "Could not connect to `{$connectTo}:{$this->port}` or it does not have a certificate matching `{$hostName}`."
+                : "Could not connect to `{$connectTo}:{$this->port}`.";
 
             throw CouldNotDownloadCertificate::unknownError($hostName, $clientErrorMessage);
         }


### PR DESCRIPTION
Hi,

This is great library, but I have 1 issue : 

- The error message does not show connected TCP port number. ( This pull request may resolve this issue )

Thanks for your contributions.