### PR TITLE
Use stream_socket_client() exception for better message

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -180,14 +180,20 @@ class Downloader
             $connectTo = $hostName;
         }
 
-        $client = @stream_socket_client(
-            "ssl://{$connectTo}:{$this->port}",
-            $errorNumber,
-            $errorDescription,
-            $this->timeout,
-            STREAM_CLIENT_CONNECT,
-            $streamContext
-        );
+        try {
+            $client = stream_socket_client(
+                "ssl://{$connectTo}:{$this->port}",
+                $errorNumber,
+                $errorDescription,
+                $this->timeout,
+                STREAM_CLIENT_CONNECT,
+                $streamContext
+            );
+        }
+        catch (\ErrorException $ex) {
+            $client = null;
+            $errorDescription = trim(str_replace('stream_socket_client():', '', $ex->getMessage()));
+        }
 
         if (! empty($errorDescription)) {
             throw $this->buildFailureException($connectTo, $errorDescription);

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\SslCertificate;
 
+use ErrorException;
 use Spatie\SslCertificate\Exceptions\CouldNotDownloadCertificate;
 use Spatie\SslCertificate\Exceptions\InvalidIpAddress;
 
@@ -190,9 +191,9 @@ class Downloader
                 $streamContext
             );
         }
-        catch (\ErrorException $ex) {
+        catch (ErrorException $exception) {
             $client = null;
-            $errorDescription = trim(str_replace('stream_socket_client():', '', $ex->getMessage()));
+            $errorDescription = trim(str_replace('stream_socket_client():', '', $exception->getMessage()));
         }
 
         if (! empty($errorDescription)) {


### PR DESCRIPTION
`stream_socket_client()`'s `$errorDescription` misses a lot of error message. Most of the time (in my cases) it's just an empty string after a connection failure. But the exception is always a useful pretty error message. `hostDoesNotExist`, `noCertificateInstalled` and `unknownError` after that still work the same.