### PR TITLE
Suppress `stream_socket_client` warnings

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -182,7 +182,7 @@ class Downloader
         }
 
         try {
-            $client = stream_socket_client(
+            $client = @stream_socket_client(
                 "ssl://{$connectTo}:{$this->port}",
                 $errorNumber,
                 $errorDescription,


### PR DESCRIPTION
Without this change, PHP warnings may pop-up:

```
PHP Warning:  stream_socket_client(): php_network_getaddresses: getaddrinfo for xxxx.xx failed: Name or service not known in vendor/spatie/ssl-certificate/src/Downloader.php on line 185
```

Seems to have been changed with https://github.com/spatie/ssl-certificate/pull/183. From what I can see, even when suppressing, error handling still happens.