### PR TITLE
Base64 encode serialized publicKeyDetail

### DIFF
--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -333,4 +333,15 @@ class SslCertificate
 
         return true;
     }
+
+    public function __serialize(): array {
+        $data = $this->toArray();
+        $data['publicKeyDetail'] = base64_encode(serialize($data['publicKeyDetail']));
+        return $data;
+    }
+    
+    public function __unserialize($data): void {
+        $data['publicKeyDetail'] = unserialize(base64_decode($data['publicKeyDetail']));
+        $this->__construct(...$data);
+    }
 }

--- a/tests/SslCertificateSerializationTest.php
+++ b/tests/SslCertificateSerializationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Carbon\Carbon;
+use Spatie\SslCertificate\SslCertificate;
+
+it('cannot json encode certificate array data', function() {
+    json_encode(
+        SslCertificate::createFromFile(__DIR__ . '/stubs/spatieCertificate.pem')->toArray()
+    );
+    
+    expect(json_last_error_msg())->toEqual('Malformed UTF-8 characters, possibly incorrectly encoded');
+});
+
+it('can json encode serialized certificate', function() {
+    $json = json_encode(
+        serialize(SslCertificate::createFromFile(__DIR__ . '/stubs/spatieCertificate.pem'))
+    );
+    
+    expect(json_last_error_msg())->toEqual('No error');
+});
+
+it('can unserialize serialized certificate', function() {
+    $serialized = serialize(SslCertificate::createFromFile(__DIR__ . '/stubs/spatieCertificate.pem'));
+
+    $unserialized = unserialize($serialized);
+
+    expect($unserialized->getDomain())->toEqual("analytics.spatie.be");
+});


### PR DESCRIPTION
I'm running into issues where the `SslCertificate` instance can't be serialized for a queue job, due to binary "malformed UTF-8" characters is some of the `publicKeyDetail`.

I'm specifically running into this in the `laravel-uptime-monitor` package, when a certificate is included in a queued `CertificateCheckSucceeded` event. See here:

https://github.com/spatie/laravel-uptime-monitor/discussions/359

This PR base64 encodes the `publicKeyDetail` part of the certificate when serializing, and handles decoding on unserialize.

I have this fork installed in my own app, and have verified it resolves the issue.

Test case added to verify serialize/unserialize works properly, and that we can `json_encode` a serialized certificate.