### PR TITLE
Implicit conversion from float to int Warning

### DIFF
--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -162,7 +162,7 @@ class SslCertificate
 
     public function lifespanInDays(): int
     {
-        return $this->validFromDate()->diffInDays($this->expirationDate(), false);
+        return (int)$this->validFromDate()->diffInDays($this->expirationDate(), false);
     }
 
     public function isExpired(): bool


### PR DESCRIPTION
Fixes WARNING - Implicit conversion from float 89.99998842592592 to int loses precision in (...)/spatie/ssl-certificate/src/SslCertificate.php on line 165

Reason:
diffInDays: float