### PR TITLE
Fix PHP 8.4 implicitly marking parameter deprecation

### DIFF
--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -170,7 +170,7 @@ class SslCertificate
         return $this->expirationDate()->isPast();
     }
 
-    public function isValid(string $url = null): bool
+    public function isValid(?string $url = null): bool
     {
         if (! Carbon::now()->between($this->validFromDate(), $this->expirationDate())) {
             return false;
@@ -203,7 +203,7 @@ class SslCertificate
         return false;
     }
 
-    public function isValidUntil(Carbon $carbon, string $url = null): bool
+    public function isValidUntil(Carbon $carbon, ?string $url = null): bool
     {
         if ($this->expirationDate()->lte($carbon)) {
             return false;


### PR DESCRIPTION
This MR fix those deprecation warning appeared in PHP 8.4:

```
PHP Deprecated:  Spatie\SslCertificate\SslCertificate::isValid(): Implicitly marking parameter $url as nullable is deprecated, the explicit nullable type must be used instead

PHP Deprecated:  Spatie\SslCertificate\SslCertificate::isValidUntil(): Implicitly marking parameter $url as nullable is deprecated, the explicit nullable type must be used instead
```